### PR TITLE
Add module.exports to dist/index.js

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30,3 +30,5 @@ exports.default = function (obj) {
 };
 
 var _preact = require('preact');
+
+module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
   },
   "devDependencies": {
     "babel-cli": "^6.7.7",
-    "babel-register": "^6.7.2",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-object-assign": "^6.5.0",
     "babel-preset-es2015": "^6.6.0",
+    "babel-register": "^6.7.2",
     "chai": "^3.5.0",
     "jscs": "^3.0.3",
     "mocha": "^3.1.2",
@@ -21,7 +22,8 @@
       "es2015"
     ],
     "plugins": [
-      "transform-object-assign"
+      "transform-object-assign",
+      "add-module-exports"
     ]
   },
   "scripts": {


### PR DESCRIPTION
This module is exactly what we needed, thanks! 👏

As a small addition, this PR uses [babel-plugin-add-module-exports](https://github.com/59naga/babel-plugin-add-module-exports) so that those of us stuck in ES5 land don't have to write `require('preact-classless-component').default`. The tests pass and no other changes are made.

Please let me know if there's anything you'd like me to do to help get this merged and published, otherwise thanks for your consideration.